### PR TITLE
Update dependencies and add reference to main.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ sudo make install
 
 > You need to set `LOADER_LIBRARY_PATH` to the build directory created in the script above before running `sbt`, i.e. `LOADER_LIBRARY_PATH=path/to/core/build sbt`
 
+You can also set environment variables by running `main.js` file in MetaCall REPL and then copy-pasting the generated export statements into your terminal
+
 To run the tests in Docker, run `sbt` then `docker` to build the image (must run `docker` from within the SBT session), and then `sbt dockerTest` to run it. Note that you should build the `metacall/core:dev` image locally since the published one might not be up to date by running `./docker-compose.sh build` in `metacall/core`'s root. Pay attention to SBT's error messages.
 
 ### Debugging

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / organization := "io.metacall"
 ThisBuild / organizationName := "MetaCall"
 
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
     scalacOptions ++= commonScalacOptions,
     scalacOptions in (Compile, console) := Seq.empty,
     libraryDependencies ++= Seq(
-      "net.java.dev.jna" % "jna" % "5.6.0",
+      "net.java.dev.jna" % "jna" % "5.13.0",
       "com.chuusai" %% "shapeless" % "2.3.3",
       "org.scalatest" %% "scalatest" % "3.2.2" % Test
     ),

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
@@ -14,6 +14,7 @@ lazy val root = (project in file("."))
     resolvers += Resolver.githubPackages("metacall"),
     libraryDependencies ++= Seq(
       "io.metacall" %% "metacall" % "0.1.0",
-      "org.scalatest" %% "scalatest" % "3.2.2" % Test
+      "org.scalatest" %% "scalatest" % "3.2.2" % Test,
+      "net.java.dev.jna" % "jna" % "5.13.0"
     )
   )

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.10.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.10.7

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,8 @@
+// format: off
 // DO NOT EDIT! This file is auto-generated.
+
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.8")
+
+// format: on

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,8 @@
+// format: off
 // DO NOT EDIT! This file is auto-generated.
+
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.8")
+
+// format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,8 @@
+// format: off
 // DO NOT EDIT! This file is auto-generated.
+
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.8")
+
+// format: on


### PR DESCRIPTION
The port now supports newer versions of JNA files which let it run on amd64 architecture. Subsequently scala and sbt versions have been updated. A reference to main.js has been made in README.md to provide an easier way to set environment variables.